### PR TITLE
Implement transactions for updating

### DIFF
--- a/GeorgiaTech/Server/Controllers/AuthorController.cs
+++ b/GeorgiaTech/Server/Controllers/AuthorController.cs
@@ -99,8 +99,21 @@ namespace Server.Controllers
         /// <remarks>NOT TESTED</remarks>
         public int Delete(Author author)
         {
-            _db.Remove(author);
-            return _db.SaveChanges();
+            int changedRows;
+            using var transaction = _db.Database.BeginTransaction();
+
+            try
+            {
+                _db.Remove(author);
+                changedRows = _db.SaveChanges();
+            }
+            catch (DbUpdateException)
+            {
+                transaction.Rollback();
+                throw; // rethrow
+            }
+
+            return changedRows;
         }
 
         /// <summary>

--- a/GeorgiaTech/Server/Controllers/AuthorController.cs
+++ b/GeorgiaTech/Server/Controllers/AuthorController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.EntityFrameworkCore;
 using Server.Models;
 
 namespace Server.Controllers
@@ -70,11 +71,23 @@ namespace Server.Controllers
         public Author Update(Author author)
         {
             if (!_db.ChangeTracker.HasChanges())
-            {
                 return null;
+
+            int changedRows;
+            using var transaction = _db.Database.BeginTransaction();
+
+            try
+            {
+                // TODO: return changed rows once IController's Update method signature has been updated
+                changedRows = _db.SaveChanges();
+                transaction.Commit();
+            }
+            catch (DbUpdateException)
+            {
+                transaction.Rollback();
+                throw;
             }
 
-            _db.SaveChanges();
             return author;
         }
 


### PR DESCRIPTION
Transactions are now used to make sure there are no hiccups during an update operation on the `Server.AuthorController`. If there is an exception thrown by the context, the transaction will be rolled back, otherwise, it'll commit.