### PR TITLE
Implement automatic author creation when creating a new material

### DIFF
--- a/GeorgiaTech/Api/Controllers/MaterialController.cs
+++ b/GeorgiaTech/Api/Controllers/MaterialController.cs
@@ -134,7 +134,7 @@ namespace Api.Controllers
                 {
                     Material = material,
                     Author = new Server.Models.Author
-                        {FirstName = author.FirstName, LastName = author.LastName}
+                        {AuthorId = author.AuthorId, FirstName = author.FirstName, LastName = author.LastName}
                 })
                 .ToList();
 


### PR DESCRIPTION
When creating a new material, the controller will look through all
authors passed as a parameter and create those that haven't been passed
with an AuthorId or aren't found in the database.