### PR TITLE
Material types api endpoint

### DIFF
--- a/GeorgiaTech/Api/Controllers/MaterialController.cs
+++ b/GeorgiaTech/Api/Controllers/MaterialController.cs
@@ -177,5 +177,18 @@ namespace Api.Controllers
             // TODO: Add if statement that checks for the right amount of changedRows
             return new OkResult();
         }
+
+        /// <summary>
+        /// Returns all available material types to the client
+        /// </summary>
+        /// <returns>An IEnumerable with all available material types</returns>
+        [HttpGet("materialtypes")]
+        public IEnumerable<MaterialType> GetMaterialTypes()
+        {
+            return _controller
+                .GetMaterialTypes()
+                .Select(mt => new MaterialType {TypeId = mt.TypeId, Type = mt.Type})
+                .ToList();
+        }
     }
 }

--- a/GeorgiaTech/Api/Controllers/MaterialController.cs
+++ b/GeorgiaTech/Api/Controllers/MaterialController.cs
@@ -38,6 +38,8 @@ namespace Api.Controllers
                 })
                 .ToList();
 
+            var materialType = new MaterialType {TypeId = material.Type.TypeId, Type = material.Type.Type};
+
             return new Material
             {
                 MaterialId = material.MaterialId,
@@ -45,7 +47,7 @@ namespace Api.Controllers
                 Title = material.Title,
                 Language =  material.Language,
                 Description = material.Description,
-                Type = material.Type,
+                Type = materialType,
                 Authors = authors,
                 MaterialSubjects = subjects,
             };

--- a/GeorgiaTech/Api/Models/Material.cs
+++ b/GeorgiaTech/Api/Models/Material.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using Server.Models;
 
 namespace Api.Models
 {

--- a/GeorgiaTech/Api/Models/MaterialType.cs
+++ b/GeorgiaTech/Api/Models/MaterialType.cs
@@ -1,0 +1,8 @@
+namespace Api.Models
+{
+    public class MaterialType
+    {
+        public int TypeId { get; set; }
+        public string Type { get; set; }
+    }
+}

--- a/GeorgiaTech/Server/Controllers/MaterialController.cs
+++ b/GeorgiaTech/Server/Controllers/MaterialController.cs
@@ -227,6 +227,15 @@ namespace Server.Controllers
         }
 
         /// <summary>
+        /// Returns an IEnumerable containing all material types saved on the database
+        /// </summary>
+        /// <returns>An IEnumerable object containing all material types</returns>
+        public IEnumerable<MaterialType> GetMaterialTypes()
+        {
+            return _context.MaterialTypes.ToList();
+        }
+
+        /// <summary>
         /// Finds and returns a MaterialSubject by its ID
         /// </summary>
         /// <param name="id">The ID of the material subject</param>

--- a/GeorgiaTech/Server/Interfaces/IMaterialController.cs
+++ b/GeorgiaTech/Server/Interfaces/IMaterialController.cs
@@ -18,6 +18,7 @@ namespace Server.Controllers
 
         public int Update(int id, Material newMaterial);
         public MaterialType FindMaterialTypeById(int id);
+        public IEnumerable<MaterialType> GetMaterialTypes();
         public MaterialSubject FindMaterialSubjectById(int id);
     }
 }


### PR DESCRIPTION
`/api/material/materialtypes` is the endpoint implemented in this PR. It'll respond with a list of all available material types that are saved on the database.

In the PR there are also the following changes:
- `MaterialType` is now a class existing in `Api.Models` so that the `Material` class can use that and have to do a full transformation from a Server model to an Api model (robustness).
- `Server.MaterialController` has a new method - `GetMaterialTypes`.