### PR TITLE
Material subjects api endpoint and correct updates

### DIFF
--- a/GeorgiaTech/Api/Controllers/MaterialController.cs
+++ b/GeorgiaTech/Api/Controllers/MaterialController.cs
@@ -34,7 +34,7 @@ namespace Api.Controllers
                 .Select(ms => new MaterialSubject
                 {
                     SubjectId = ms.MaterialSubject.SubjectId,
-                    Subject = ms.MaterialSubject.SubjectName,
+                    SubjectName = ms.MaterialSubject.SubjectName,
                 })
                 .ToList();
 
@@ -77,7 +77,7 @@ namespace Api.Controllers
 
             var materialSubjects = materialData.MaterialSubjects
                 .Select(subject => new Server.Models.MaterialSubject
-                    { SubjectId = subject.SubjectId, SubjectName = subject.Subject })
+                    { SubjectId = subject.SubjectId, SubjectName = subject.SubjectName })
                 .ToList();
 
             var authors = materialData.Authors
@@ -124,7 +124,7 @@ namespace Api.Controllers
                 .Select(subject => new Server.Models.MaterialSubjects
                     {
                         MaterialSubject = new Server.Models.MaterialSubject
-                            {SubjectName = subject.Subject, SubjectId = subject.SubjectId},
+                            {SubjectName = subject.SubjectName, SubjectId = subject.SubjectId},
                         Material = material
                     })
                 .ToList();

--- a/GeorgiaTech/Api/Controllers/MaterialController.cs
+++ b/GeorgiaTech/Api/Controllers/MaterialController.cs
@@ -175,5 +175,15 @@ namespace Api.Controllers
             // TODO: Add if statement that checks for the right amount of changedRows
             return new OkResult();
         }
+
+        [HttpGet("materialsubjects")]
+        public IEnumerable<MaterialSubject> GetMaterialSubjects()
+        {
+            return _controller
+                .GetMaterialSubjects()
+                .Select(subject => new MaterialSubject
+                    {SubjectId = subject.SubjectId, SubjectName = subject.SubjectName})
+                .ToList();
+        }
     }
 }

--- a/GeorgiaTech/Api/Controllers/VolumeController.cs
+++ b/GeorgiaTech/Api/Controllers/VolumeController.cs
@@ -105,7 +105,7 @@ namespace Api.Controllers
                     var materialSubjects = volume.Material.MaterialSubjects.Select(e => new Models.MaterialSubject
                     {
                         SubjectId = e.MaterialSubject.SubjectId,
-                        Subject = e.MaterialSubject.SubjectName
+                        SubjectName = e.MaterialSubject.SubjectName
                     }).ToList();
                     volumeMaterial.MaterialSubjects = materialSubjects;
                 }

--- a/GeorgiaTech/Api/Models/MaterialSubject.cs
+++ b/GeorgiaTech/Api/Models/MaterialSubject.cs
@@ -1,9 +1,8 @@
-﻿using System;
-namespace Api.Models
+﻿namespace Api.Models
 {
     public class MaterialSubject
     {
         public int SubjectId { get; set; }
-        public string Subject { get; set; }
+        public string SubjectName { get; set; }
     }
 }

--- a/GeorgiaTech/Server/Controllers/MaterialController.cs
+++ b/GeorgiaTech/Server/Controllers/MaterialController.cs
@@ -209,11 +209,12 @@ namespace Server.Controllers
             var materialSubjects = newMaterial.MaterialSubjects
                 .Select(ms =>
                 {
-                    var subject = _context.MaterialSubjects.Find(ms.SubjectId);
-                    if (subject == null)
+                    var subject = ms.MaterialSubject;
+                    var fetchedSubject = _context.MaterialSubjects.Find(subject.SubjectId);
+                    if (fetchedSubject == null)
                         throw new ArgumentException("MaterialSubjects must already exist", nameof(newMaterial.MaterialSubjects));
 
-                    return new MaterialSubjects {MaterialSubject = subject, Material = material};
+                    return new MaterialSubjects {MaterialSubject = fetchedSubject, Material = material};
                 }).ToList();
 
             var materialAuthors = newMaterial.MaterialAuthors
@@ -238,6 +239,8 @@ namespace Server.Controllers
                     return new MaterialAuthor {Author = fetchedAuthor, Material = material};
                 }).ToList();
 
+            // remove previous material subjects
+            _context.RemoveRange(material.MaterialSubjects);
             material.MaterialSubjects = materialSubjects;
 
             // remove pre-existing authors

--- a/GeorgiaTech/Server/Controllers/MaterialController.cs
+++ b/GeorgiaTech/Server/Controllers/MaterialController.cs
@@ -236,5 +236,14 @@ namespace Server.Controllers
         {
             return _context.MaterialSubjects.Find(id);
         }
+
+        /// <summary>
+        /// Returns an IEnumerable object containing all MaterialSubject entities saved on the database
+        /// </summary>
+        /// <returns>An IEnumerable object containing all MaterialSubject entities on the database</returns>
+        public IEnumerable<MaterialSubject> GetMaterialSubjects()
+        {
+            return _context.MaterialSubjects.ToList();
+        }
     }
 }

--- a/GeorgiaTech/Server/Interfaces/IMaterialController.cs
+++ b/GeorgiaTech/Server/Interfaces/IMaterialController.cs
@@ -19,5 +19,6 @@ namespace Server.Controllers
         public int Update(int id, Material newMaterial);
         public MaterialType FindMaterialTypeById(int id);
         public MaterialSubject FindMaterialSubjectById(int id);
+        public IEnumerable<MaterialSubject> GetMaterialSubjects();
     }
 }


### PR DESCRIPTION
This PR will update the `Server.MaterialController.Update` method to update material subjects correctly (that is, it'll delete previous `MaterialSubjects (the joining table entities)` and assign the new ones).

Furthermore, `/api/material/materialsubjects` endpoint is implemented to return all available material subjects as an `IEnumerable`.